### PR TITLE
印開發環境，改聲學host from位置

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ RUN git log -1 --format="%H"
 
 RUN pip3 freeze
 
-# test 04090959
+# test 04091009 from exp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM localhost:5000/siann1-hak8_boo5-hing5:14
+FROM localhost:5000/siann1-hak8_boo5-hing5:20
 
 MAINTAINER sih4sing5hong5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM localhost:5000/siann1-hak8_boo5-hing5:24
+FROM localhost:5000/siann1-hak8_boo5-hing5:21
 
 MAINTAINER sih4sing5hong5
 
@@ -31,4 +31,4 @@ RUN git log -1 --format="%H"
 
 RUN pip3 freeze
 
-# test 04090954
+# test 04090956

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM siann
+FROM gotw/siann1-hak8_boo5-hing5:6
 
 MAINTAINER sih4sing5hong5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM localhost:5000/siann1-hak8_boo5-hing5:21
+FROM localhost:5000/siann1-hak8_boo5-hing5:24
 
 MAINTAINER sih4sing5hong5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,5 @@ WORKDIR /usr/local/kaldi/tools
 RUN git log -1 --format="%H"
 
 RUN pip3 freeze
+
+# test 0409

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM localhost:5000/siann1-hak8_boo5-hing5:21
+FROM localhost:5000/siann1-hak8_boo5-hing5:24
 
 MAINTAINER sih4sing5hong5
 
@@ -31,4 +31,4 @@ RUN git log -1 --format="%H"
 
 RUN pip3 freeze
 
-# test 04090956
+# test 04090959

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,9 @@ RUN bash -c 'rm -rf exp/{tri1,tri2,tri3,tri4}/decode_train_dev*'
 RUN bash -c 'time bash -x 走評估.sh data/lang_free tshi3/train_free'
 
 RUN bash -c 'time bash 看結果.sh'
+
+# 印開發環境
+WORKDIR /usr/local/kaldi/tools
+RUN git log -1 --format="%H"
+
+RUN pip3 freeze

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,3 @@ WORKDIR /usr/local/kaldi/tools
 RUN git log -1 --format="%H"
 
 RUN pip3 freeze
-
-# test 0409

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,5 @@ WORKDIR /usr/local/kaldi/tools
 RUN git log -1 --format="%H"
 
 RUN pip3 freeze
+
+# test

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,3 @@ WORKDIR /usr/local/kaldi/tools
 RUN git log -1 --format="%H"
 
 RUN pip3 freeze
-
-# test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gotw/siann1-hak8_boo5-hing5:6
+FROM localhost:5000/siann1-hak8_boo5-hing5:14
 
 MAINTAINER sih4sing5hong5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM localhost:5000/siann1-hak8_boo5-hing5:24
+FROM localhost:5000/siann1-hak8_boo5-hing5:21
 
 MAINTAINER sih4sing5hong5
 
@@ -30,5 +30,3 @@ WORKDIR /usr/local/kaldi/tools
 RUN git log -1 --format="%H"
 
 RUN pip3 freeze
-
-# test 04091009 from exp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM localhost:5000/siann1-hak8_boo5-hing5:20
+FROM localhost:5000/siann1-hak8_boo5-hing5:24
 
 MAINTAINER sih4sing5hong5
 
@@ -30,3 +30,5 @@ WORKDIR /usr/local/kaldi/tools
 RUN git log -1 --format="%H"
 
 RUN pip3 freeze
+
+# test 04090954


### PR DESCRIPTION
加印開發環境，改聲學host from位置，GPU主機接續build同理可改成
```
FROM 10.32.0.120:5000/siann1-hak8_boo5-hing5:14(要接的build序號，可自CI/EXP查看)
...
```

位於內網，且主機亦需先新增 /etc/docker/daemon.json 
```
## /etc/docker/daemon.json
 { "insecure-registries":["10.32.0.120:5000"] } 
```
才能正常docker build(pull)

REF
https://github.com/docker/distribution/issues/1874#issuecomment-352417374